### PR TITLE
Modernização de versões e retirada de find-links

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -18,7 +18,6 @@ parts =
 
 find-links +=
                http://pybrary.net/pyPdf/
-	           https://github.com/erocarrera/pydot/tarball/master#egg=pydot
                https://github.com/odoo-brazil/pyxmlsec/tarball/master#egg=pyxmlsec-master
 
 versions = versions
@@ -156,7 +155,7 @@ lxml = 3.3.5
 mako = 0.6.2
 psycopg2 = 2.4.4
 python-chart = 1.39
-pydot = 1.0.28
+pydot = 1.1.0
 pyparsing = 1.5.6
 python-dateutil = 1.5
 python-ldap = 2.4.9

--- a/default.cfg
+++ b/default.cfg
@@ -17,7 +17,6 @@ parts =
 
 
 find-links +=
-               http://pybrary.net/pyPdf/
                https://github.com/odoo-brazil/pyxmlsec/tarball/master#egg=pyxmlsec-master
 
 versions = versions

--- a/default.cfg
+++ b/default.cfg
@@ -16,7 +16,7 @@ parts =
     env
 
 
-find-links +=  http://download.gna.org/pychart/
+find-links +=
                http://pybrary.net/pyPdf/
 	           https://github.com/erocarrera/pydot/tarball/master#egg=pydot
                https://github.com/odoo-brazil/pyxmlsec/tarball/master#egg=pyxmlsec-master
@@ -155,7 +155,7 @@ gdata = 2.0.16
 lxml = 3.3.5
 mako = 0.6.2
 psycopg2 = 2.4.4
-pychart = 1.39
+python-chart = 1.39
 pydot = 1.0.28
 pyparsing = 1.5.6
 python-dateutil = 1.5
@@ -199,7 +199,7 @@ eggs = behave
        lxml
        mako
        psycopg2
-       pychart
+       python-chart
        pydot
        pyparsing
        python-dateutil


### PR DESCRIPTION
Retira find-links inúteis e seleciona versões mais apropriadas de alguns pacotes.

Veja cada commit para mais detalhes.

Cada find-link inútil aumenta o tempo de execução do buildout. Em particular o do PyChart que demora um tempo antes de dar timeout.